### PR TITLE
ci: deploy 파이프라인을 구성한다

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test3
+            ghcr.io/nexters/misikapi/misikapi:test4
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -83,6 +83,6 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test3
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test4
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test3
+          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,5 +84,5 @@ jobs:
         run: |
           sudo docker pull ghcr.io/nexters/misikapi/misikapi:test3
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:test3
+          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test3
             

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'release'
-  pull_request: # 테스트용. 잘 되는거 확인 후 삭제
-    branches:
-      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test3
+            ghcr.io/nexters/misikapi/misikapi:test2
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -83,6 +83,6 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test3
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test2
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test3
+          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test
+            ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -83,6 +83,6 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test
+          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
             "DB_PASSWORD=${{ secrets.DB_PASSWORD }}"
             "REDIS_HOST=${{ secrets.REDIS_HOST }}"
             "REDIS_PORT=${{ secrets.REDIS_PORT }}"
+            "CLOVA_AUTHORIZATION=${{ secrets.CLOVA_AUTHORIZATION }}"
 
   deploy:
     needs: build
@@ -85,4 +86,3 @@ jobs:
           sudo docker pull ghcr.io/nexters/misikapi/misikapi:test3
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
           sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test3
-            

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test2
+            ghcr.io/nexters/misikapi/misikapi:test
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -83,6 +83,6 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test2
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test2
+          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,91 @@
+name: 🎇 Deployer
+
+on:
+  push:
+    branches:
+      - 'release'
+  pull_request: # 테스트용. 잘 되는거 확인 후 삭제
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    name: build and set image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kotlin-version: [ 1.9.22 ]
+        java-version: [ 21 ]
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up JDK 21 and Kotlin 1.9.22
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java-version }}
+          kotlin-version: ${{ matrix.kotlin-version }}
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: build server
+        run: ./gradlew build
+
+      - name: move jar file to deploy api
+        run: mv ./build/libs/*.jar ./deploy/api/
+
+      - name: docker arm64 build set up - qemu
+        uses: docker/setup-qemu-action@v2
+
+      - name: docker arm64 build set up - buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: login github container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: extract version
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        id: extract_version_name
+
+      - name: build and push api server
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/arm64/v8
+          push: true
+          tags: |
+            ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
+          build-args: |
+            "DB_URL=${{ secrets.DB_URL }}"
+            "DB_USERNAME=${{ secrets.DB_USERNAME }}"
+            "DB_PASSWORD=${{ secrets.DB_PASSWORD }}"
+            "REDIS_HOST=${{ secrets.REDIS_HOST }}"
+            "REDIS_PORT=${{ secrets.REDIS_PORT }}"
+
+  deploy:
+    needs: build
+    name: deploy
+    runs-on: self-hosted
+    steps:
+      - name: extract version
+        run: echo "##[set-output name=version;]$(echo '${{ github.event.head_commit.message }}' | egrep -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')"
+        id: extract_version_name
+
+      - name: run api server
+        run: |
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
+          sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
+          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
+            

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,9 +39,6 @@ jobs:
       - name: build server
         run: ./gradlew build
 
-      - name: move jar file to deploy api
-        run: mv ./build/libs/*.jar ./deploy/api/
-
       - name: docker arm64 build set up - qemu
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/arm64/v8
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test
+            ghcr.io/nexters/misikapi/misikapi:test2
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -82,7 +82,7 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test2
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:test
+          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:test2
             

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test4
+            ghcr.io/nexters/misikapi/misikapi:test3
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -83,6 +83,6 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test4
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test3
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test4
+          sudo docker run -d -p 8080:8080 --network docker-compose_misik_api_network ghcr.io/nexters/misikapi/misikapi:test3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/arm64/v8
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/nexters/misikapi/misikapi:test2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:test2
+            ghcr.io/nexters/misikapi/misikapi:test3
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -82,7 +82,7 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test2
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test3
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:test2
+          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:test3
             

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           platforms: linux/arm64/v8
           push: true
           tags: |
-            ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
+            ghcr.io/nexters/misikapi/misikapi:test
           build-args: |
             "DB_URL=${{ secrets.DB_URL }}"
             "DB_USERNAME=${{ secrets.DB_USERNAME }}"
@@ -82,7 +82,7 @@ jobs:
 
       - name: run api server
         run: |
-          sudo docker pull ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
+          sudo docker pull ghcr.io/nexters/misikapi/misikapi:test
           sudo docker ps -q --filter "expose=8080" | xargs sudo docker stop | xargs sudo docker rm
-          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:${{ steps.extract_version_name.outputs.version }}
+          sudo docker run -d -p 8080:8080 --network misik_api_network ghcr.io/nexters/misikapi/misikapi:test
             

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG DB_USERNAME
 ARG DB_PASSWORD
 ARG REDIS_HOST
 ARG REDIS_PORT
+ARG CLOVA_AUTHORIZATION
 
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} misik-api.jar
@@ -13,11 +14,13 @@ ENV db_url=${DB_URL} \
   db_username=${DB_USERNAME} \
   db_password=${DB_PASSWORD} \
   redis_host=${REDIS_HOST} \
-  redis_port=${REDIS_PORT}
+  redis_port=${REDIS_PORT} \
+  clova_authorization=${CLOVA_AUTHORIZATION}
 
 ENTRYPOINT java -jar misik-api.jar \
   --spring.datasource.url=${db_url} \
   --spring.datasource.username=${db_username} \
   --spring.datasource.password=${db_password} \
   --netx.host=${redis_host} \
-  --netx.port=${redis_port}
+  --netx.port=${redis_port} \
+  --me.misik.chatbot.clova.authorization=${clova_authorization}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM arm64v8/openjdk:21
+
+ARG DB_URL
+ARG DB_USERNAME
+ARG DB_PASSWORD
+ARG REDIS_HOST
+ARG REDIS_PORT
+
+ARG JAR_FILE=./*.jar
+COPY ${JAR_FILE} misik-api.jar
+
+ENV db_url=${DB_URL} \
+  db_username=${DB_USERNAME} \
+  db_password=${DB_PASSWORD} \
+  redis_host=${REDIS_HOST} \
+  redis_port=${REDIS_PORT}
+
+ENTRYPOINT java -jar misik-api.jar \
+  --spring.datasource.url=${db_url} \
+  --spring.datasource.username=${db_username} \
+  --spring.datasource.password=${db_password} \
+  --netx.host=${redis_host} \
+  --netx.port=${redis_port}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG DB_PASSWORD
 ARG REDIS_HOST
 ARG REDIS_PORT
 
-ARG JAR_FILE=./*.jar
+ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} misik-api.jar
 
 ENV db_url=${DB_URL} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/openjdk:21
+FROM openjdk:21-jdk
 
 ARG DB_URL
 ARG DB_USERNAME


### PR DESCRIPTION
# 요약
deploy 파이프라인을 구성했습니다.

# 어떻게 구현했는지
1. 빌드 후 이미지를 만듭니다. 
   이때 이미지 명은 release: 0.1.0과 같이 입력하면, 뒤의 버전이 이미지명에 포함됩니다. -> 잘못 배포했을때 바로 롤백하기 위해서 이미지에 버저닝을 추가했습니다.
2. nexters 오가니제이션 packages에 docker 파일을 push 합니다.
3. 저희 서버에 미리 띄워둔 self hosted runner에 deploy 요청을 보냅니다.
<img width="786" alt="스크린샷 2025-01-29 오후 12 55 41" src="https://github.com/user-attachments/assets/145371d0-905a-4cbd-8100-1752939519d9" />

4. 배포를 시작하기전에, nexters 오기나지에션 packages에서 최신 버전을 다운로드 합니다.
5. 서버에서 기존에 실행중인 8080포트를 찾아 shutdown 시키고(gracefully하게 시도) 
6. 새로운 버전을 띄웁니다. (무중단 배포 아님)

# 이슈번호
<!-- 다음과 같이 작성해주세요. - close #1 -->
- close #8 
