### PR TITLE
feat: 영수증 최대 생성 길이를 조정한다

### DIFF
--- a/src/main/kotlin/me/misik/api/core/Chatbot.kt
+++ b/src/main/kotlin/me/misik/api/core/Chatbot.kt
@@ -12,7 +12,7 @@ fun interface Chatbot {
 
     data class Request(
         val messages: List<Message>,
-        val maxTokens: Int = 100,
+        val maxTokens: Int = 1000,
         val includeAiFilters: Boolean = true,
     ) {
         data class Message(


### PR DESCRIPTION
# 요약
영수증이 생성되다가 잘리지 않도록 영수증 최대 생성 길이를 늘립니다

# 어떻게 구현했는지
Clova LLM Chat Completions 호출 시 maxTokens를 조정합니다 

# 이슈번호
<!-- 다음과 같이 작성해주세요. - close #1 -->
close #25 