### PR TITLE
refactor: Ocrparser max token to 1000

### DIFF
--- a/src/main/kotlin/me/misik/api/core/OcrParser.kt
+++ b/src/main/kotlin/me/misik/api/core/OcrParser.kt
@@ -11,7 +11,7 @@ fun interface OcrParser {
 
     data class Request(
         val messages: List<Message>,
-        val maxTokens: Int = 100,
+        val maxTokens: Int = 1000,
         val includeAiFilters: Boolean = true,
     ) {
         data class Message(


### PR DESCRIPTION
# 요약
Ocrparser의 max token을 1000으로 늘렸습니다.

# 어떻게 구현했는지
Ocrparser의 max token을 1000으로 늘렸습니다.

# 이슈번호
<!-- 다음과 같이 작성해주세요. - close #1 -->
- close #46 
