### PR TITLE
refactor: ocrParser에 readTimeout을 60초로 늘린다

### DIFF
--- a/src/main/kotlin/me/misik/api/infra/ClovaChatbotConfiguration.kt
+++ b/src/main/kotlin/me/misik/api/infra/ClovaChatbotConfiguration.kt
@@ -7,11 +7,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.support.RestClientAdapter
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import kotlin.time.Duration.Companion.milliseconds
+
 
 @Configuration
 class ClovaChatbotConfiguration(
@@ -39,12 +42,16 @@ class ClovaChatbotConfiguration(
 
     @Bean
     fun ocrParser(): OcrParser {
+        val clientHttpRequestFactory = HttpComponentsClientHttpRequestFactory()
+        clientHttpRequestFactory.setReadTimeout(60000)
+
         val restClient = RestClient.builder()
             .baseUrl(chatbotUrl)
             .defaultHeaders { headers ->
                 headers.add(HttpHeaders.AUTHORIZATION, "Bearer $authorization")
                 headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             }
+            .requestFactory(clientHttpRequestFactory)
             .build()
 
         val httpServiceProxyFactory = HttpServiceProxyFactory


### PR DESCRIPTION
# 요약
ocrParser에 readTimeout을 60초로 늘린다

# 어떻게 구현했는지
ocrParser에 readTimeout을 60초로 늘린다

# 이슈번호
<!-- 다음과 같이 작성해주세요. - close #1 -->
- close #53 